### PR TITLE
GH-1 bump Java version to 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ configure(javaProjects) {
 
   if (!project.properties.containsKey('cfgJavaVersion')) {
     project.ext {
-      cfgJavaVersion = '1.7'
+      cfgJavaVersion = '8'
     }
   }
 


### PR DESCRIPTION
Sets the default Java version.

No error checking is done, verifying that the Java manually set is indeed 8 or newer.